### PR TITLE
Fix/cluster instance lifecycle

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     args: ['--allow-missing-credentials']
   - id: trailing-whitespace
 - repo: git://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.31.0
+  rev: v1.32.0
   hooks:
   - id: terraform_fmt
   - id: terraform_docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 <a name="unreleased"></a>
 ## [Unreleased]
 
-- Update module versions to support v3 provider
+- Add licecycle to ignore changes for engine_version
+
+
+<a name="1.2.1"></a>
+## [1.2.1] - 2020-08-05
+
+- Feature/v3 provider support ([#3](https://github.com/umotif-public/terraform-aws-rds-aurora/issues/3))
 
 
 <a name="1.2.0"></a>
@@ -36,7 +42,8 @@ All notable changes to this project will be documented in this file.
 - Initial commit
 
 
-[Unreleased]: https://github.com/umotif-public/terraform-aws-rds-aurora/compare/1.2.0...HEAD
+[Unreleased]: https://github.com/umotif-public/terraform-aws-rds-aurora/compare/1.2.1...HEAD
+[1.2.1]: https://github.com/umotif-public/terraform-aws-rds-aurora/compare/1.2.0...1.2.1
 [1.2.0]: https://github.com/umotif-public/terraform-aws-rds-aurora/compare/1.1.0...1.2.0
 [1.1.0]: https://github.com/umotif-public/terraform-aws-rds-aurora/compare/1.0.1...1.1.0
 [1.0.1]: https://github.com/umotif-public/terraform-aws-rds-aurora/compare/1.0.0...1.0.1

--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ module "rds-aurora-mysql" {
 
   name_prefix         = "example-aurora-mysql"
   engine              = "aurora-mysql"
-  engine_version      = "5.7.12"
+  engine_version      = "5.7.mysql_aurora.2.08.1"
   deletion_protection = true
 
   vpc_id  = module.vpc.vpc_id
   subnets = module.vpc.public_subnets
 
   replica_count                       = 2
-  instance_type                       = "db.r5.large"
+  instance_type                       = "db.t3.medium"
   apply_immediately                   = true
   skip_final_snapshot                 = true
 
@@ -30,7 +30,7 @@ module "rds-aurora-mysql" {
 
   iam_database_authentication_enabled = true
 
-  allowed_cidr_blocks             = ["10.10.0.0/24", "20.10.0.0/24"]
+  allowed_cidr_blocks             = ["10.10.0.0/24", "10.20.0.0/24", "10.30.0.0/24"]
 
   create_security_group = true
 

--- a/examples/aurora-mysql/main.tf
+++ b/examples/aurora-mysql/main.tf
@@ -10,7 +10,7 @@ data "aws_region" "current" {}
 #####
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 2.32"
+  version = "~> 2.48"
 
   name = "simple-vpc"
 
@@ -125,7 +125,7 @@ module "aurora" {
   name_prefix         = "example-aurora-mysql"
   database_name       = "databaseName"
   engine              = "aurora-mysql"
-  engine_version      = "5.7.12"
+  engine_version      = "5.7.mysql_aurora.2.08.1"
   deletion_protection = false
 
   vpc_id  = module.vpc.vpc_id
@@ -160,7 +160,7 @@ module "aurora" {
     }
   ]
 
-  allowed_cidr_blocks = ["10.10.0.0/24", "20.10.0.0/24"]
+  allowed_cidr_blocks = ["10.10.0.0/24", "10.20.0.0/24", "10.30.0.0/24"]
 
   monitoring_interval = 60
 

--- a/main.tf
+++ b/main.tf
@@ -186,6 +186,12 @@ resource "aws_rds_cluster_instance" "main" {
     var.tags,
     var.cluster_instance_tags
   )
+
+  lifecycle {
+    ignore_changes = [
+      engine_version
+    ]
+  }
 }
 
 #####


### PR DESCRIPTION
# Description

Lifecycle rule added to `aws_rds_cluster_instance` allows for fluent upgrades of aurora engine versions.