### PR TITLE
Add support for parameter groups and variables

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     args: ['--allow-missing-credentials']
   - id: trailing-whitespace
 - repo: git://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.32.0
+  rev: v1.43.0
   hooks:
   - id: terraform_fmt
   - id: terraform_docs

--- a/README.md
+++ b/README.md
@@ -3,18 +3,18 @@ Terraform module which creates AWS RDS Aurora resources. This module was created
 
 ## Terraform versions
 
-Terraform 0.12. Pin module version to `~> v1.0`. Submit pull-requests to `master` branch.
+Terraform 0.12. Pin module version to `~> v2.0`. Submit pull-requests to `master` branch.
 
 ## Usage
 
 ```hcl
 module "rds-aurora-mysql" {
   source = "umotif-public/rds-aurora/aws"
-  version = "~> 1.2.0"
+  version = "~> 2.0.0"
 
   name_prefix         = "example-aurora-mysql"
   engine              = "aurora-mysql"
-  engine_version      = "5.7.mysql_aurora.2.08.1"
+  engine_version      = "5.7.mysql_aurora.2.09.0"
   deletion_protection = true
 
   vpc_id  = module.vpc.vpc_id
@@ -78,20 +78,21 @@ Module managed by [Marcin Cuber](https://github.com/marcincuber) [LinkedIn](http
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.6, < 0.14 |
-| aws | >= 2.45, < 4.0 |
-| random | >= 2.2 |
+| aws | >= 3.8, < 4.0 |
+| random | >= 2.3 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.45, < 4.0 |
-| random | >= 2.2 |
+| aws | >= 3.8, < 4.0 |
+| random | >= 2.3 |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| allow\_major\_version\_upgrade | Enable to allow major engine version upgrades when changing engine versions. Defaults to false | `bool` | `null` | no |
 | allowed\_cidr\_blocks | A list of CIDR blocks which are allowed to access the database | `list(string)` | `[]` | no |
 | allowed\_security\_groups | A list of Security Group ID's to allow access to. | `list(string)` | `[]` | no |
 | apply\_immediately | Determines whether or not any DB modifications are applied immediately, or during the maintenance window | `bool` | `false` | no |
@@ -100,9 +101,11 @@ Module managed by [Marcin Cuber](https://github.com/marcincuber) [LinkedIn](http
 | backup\_retention\_period | How long to keep backups for (in days) | `number` | `7` | no |
 | ca\_cert\_identifier | The identifier of the CA certificate for the DB instance. | `string` | `"rds-ca-2019"` | no |
 | cluster\_instance\_tags | Additional tags for the cluster instance | `map(string)` | `{}` | no |
+| cluster\_parameters | A list of cluster parameter objects | <pre>list(object({<br>    name         = string<br>    value        = string<br>    apply_method = string<br>  }))</pre> | `[]` | no |
 | cluster\_tags | Additional tags for the cluster | `map(string)` | `{}` | no |
 | copy\_tags\_to\_snapshot | Copy all Cluster tags to snapshots. | `bool` | `false` | no |
 | create\_monitoring\_role | Whether to create the IAM role for RDS enhanced monitoring | `bool` | `true` | no |
+| create\_parameter\_group | Whether to create parameter groups for RDS cluster and RDS instances | `bool` | `true` | no |
 | create\_security\_group | Whether to create security group for RDS cluster | `bool` | `true` | no |
 | database\_name | Name for an automatically created database on cluster creation | `string` | `""` | no |
 | db\_cluster\_parameter\_group\_name | The name of a DB Cluster parameter group to use | `string` | `null` | no |
@@ -113,7 +116,8 @@ Module managed by [Marcin Cuber](https://github.com/marcincuber) [LinkedIn](http
 | enabled\_cloudwatch\_logs\_exports | List of object which define log types to export to cloudwatch. See in examples. | `list` | `[]` | no |
 | engine | Aurora database engine type, currently aurora, aurora-mysql or aurora-postgresql | `string` | `"aurora"` | no |
 | engine\_mode | The database engine mode. Valid values: global, parallelquery, provisioned, serverless. | `string` | `"provisioned"` | no |
-| engine\_version | Aurora database engine version. | `string` | `"5.7.12"` | no |
+| engine\_parameter\_family | The database engine paramater group family | `string` | `"aurora-mysql5.7"` | no |
+| engine\_version | Aurora database engine version. | `string` | `"5.7.mysql_aurora.2.09.0"` | no |
 | final\_snapshot\_identifier\_prefix | The prefix name to use when creating a final snapshot on cluster destroy, appends a random 8 digits to name to ensure it's unique too. | `string` | `"final"` | no |
 | global\_cluster\_identifier | The global cluster identifier specified on aws\_rds\_global\_cluster | `string` | `""` | no |
 | iam\_database\_authentication\_enabled | Specifies whether IAM Database authentication should be enabled or not. Not all versions and instances are supported. Refer to the AWS documentation to see which versions are supported. | `bool` | `true` | no |
@@ -124,6 +128,7 @@ Module managed by [Marcin Cuber](https://github.com/marcincuber) [LinkedIn](http
 | monitoring\_interval | The interval (seconds) between points when Enhanced Monitoring metrics are collected. The default is 0. Valid Values: 0, 1, 5, 10, 15, 30, 60. | `number` | `0` | no |
 | monitoring\_role\_arn | IAM role for RDS to send enhanced monitoring metrics to CloudWatch | `string` | `""` | no |
 | name\_prefix | Prefix Name used across all resources | `string` | n/a | yes |
+| parameters | A list of parameter objects | <pre>list(object({<br>    name  = string<br>    value = string<br>  }))</pre> | `[]` | no |
 | password | Master DB password | `string` | `""` | no |
 | performance\_insights\_enabled | Specifies whether Performance Insights is enabled or not. | `bool` | `false` | no |
 | performance\_insights\_kms\_key\_id | The ARN for the KMS key to encrypt Performance Insights data. | `string` | `""` | no |

--- a/examples/aurora-mysql/main.tf
+++ b/examples/aurora-mysql/main.tf
@@ -125,7 +125,7 @@ module "aurora" {
   name_prefix         = "example-aurora-mysql"
   database_name       = "databaseName"
   engine              = "aurora-mysql"
-  engine_version      = "5.7.mysql_aurora.2.08.1"
+  engine_version      = "5.7.mysql_aurora.2.09.0"
   deletion_protection = false
 
   vpc_id  = module.vpc.vpc_id
@@ -133,12 +133,12 @@ module "aurora" {
 
   kms_key_id = module.kms.key_arn
 
-  replica_count                       = 1
-  instance_type                       = "db.t3.medium"
-  apply_immediately                   = true
-  skip_final_snapshot                 = true
-  db_parameter_group_name             = aws_db_parameter_group.aurora_mysql_db_57_parameter_group.id
-  db_cluster_parameter_group_name     = aws_rds_cluster_parameter_group.aurora_mysql_db_57_cluster_parameter_group.id
+  replica_count               = 1
+  instance_type               = "db.t3.medium"
+  apply_immediately           = true
+  allow_major_version_upgrade = true
+  skip_final_snapshot         = true
+
   iam_database_authentication_enabled = true
 
   enabled_cloudwatch_logs_exports = [
@@ -177,15 +177,5 @@ module "aurora" {
   tags = {
     Environment = "test"
   }
-}
-
-resource "aws_db_parameter_group" "aurora_mysql_db_57_parameter_group" {
-  name   = "test-aurora-mysql-db-57-parameter-group"
-  family = "aurora-mysql5.7"
-}
-
-resource "aws_rds_cluster_parameter_group" "aurora_mysql_db_57_cluster_parameter_group" {
-  name   = "test-aurora-mysql-db-57-cluster-parameter-group"
-  family = "aurora-mysql5.7"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -4,6 +4,12 @@ variable "create_security_group" {
   default     = true
 }
 
+variable "create_parameter_group" {
+  type        = bool
+  description = "Whether to create parameter groups for RDS cluster and RDS instances"
+  default     = true
+}
+
 variable "name_prefix" {
   description = "Prefix Name used across all resources"
   type        = string
@@ -120,6 +126,12 @@ variable "auto_minor_version_upgrade" {
   default     = true
 }
 
+variable "allow_major_version_upgrade" {
+  description = "Enable to allow major engine version upgrades when changing engine versions. Defaults to false"
+  type        = bool
+  default     = null
+}
+
 variable "db_parameter_group_name" {
   description = "The name of a DB parameter group to use"
   type        = string
@@ -165,7 +177,12 @@ variable "engine" {
 variable "engine_version" {
   description = "Aurora database engine version."
   type        = string
-  default     = "5.7.12"
+  default     = "5.7.mysql_aurora.2.09.0"
+}
+
+variable "engine_parameter_family" {
+  description = "The database engine paramater group family"
+  default     = "aurora-mysql5.7"
 }
 
 variable "enable_http_endpoint" {
@@ -360,4 +377,23 @@ variable "cluster_instance_tags" {
   description = "Additional tags for the cluster instance"
   type        = map(string)
   default     = {}
+}
+
+variable "parameters" {
+  type = list(object({
+    name  = string
+    value = string
+  }))
+  description = "A list of parameter objects"
+  default     = []
+}
+
+variable "cluster_parameters" {
+  type = list(object({
+    name         = string
+    value        = string
+    apply_method = string
+  }))
+  description = "A list of cluster parameter objects"
+  default     = []
 }

--- a/versions.tf
+++ b/versions.tf
@@ -2,8 +2,8 @@ terraform {
   required_version = ">= 0.12.6, < 0.14"
 
   required_providers {
-    aws    = ">= 2.45, < 4.0"
-    random = ">= 2.2"
+    aws    = ">= 3.8, < 4.0"
+    random = ">= 2.3"
   }
 }
 


### PR DESCRIPTION
# Description

1. Add full support for parameter groups
2. Add support for `allow_major_version_upgrade` argument
3. Upgrade minimum provider versions
4. Change engine_version default value to 5.7.mysql_aurora.2.09.0

This PR will form `2.0.0` release of this module