### PR TITLE
Add route53 module

### DIFF
--- a/route53.tf
+++ b/route53.tf
@@ -1,0 +1,34 @@
+locals {
+  route53_record = "rds-${var.environment}-${var.name_prefix}"
+  route53_read_record = "rds-ro-${var.environment}-${var.name_prefix}"
+}
+
+module "private_records" {
+    count = var.private_record ? 1 : 0
+
+    providers = {
+	  aws = aws.blu_shared
+    }
+
+    private_zone  = true
+    zone_name     = var.private_record_domain
+
+    source = "git::git@github.com:Pagnet/tf-modules.git//aws-route53/modules/records"
+    records = [
+    {
+      name      = local.route53_record
+      type      = "CNAME"
+      ttl       = "300"
+      records   = [ var.enable_global_cluster ? join("", aws_rds_cluster.global.*.endpoint) : join("", aws_rds_cluster.main.*.endpoint) ]
+    },
+
+    {
+      name      = local.route53_read_record
+      type      = "CNAME"
+      ttl       = "300"
+      records   = [ var.enable_global_cluster ? join("", aws_rds_cluster.global.*.reader_endpoint) : join("", aws_rds_cluster.main.*.reader_endpoint) ]
+    }
+  ]
+}
+
+

--- a/variables.tf
+++ b/variables.tf
@@ -427,3 +427,29 @@ variable "s3_import" {
   type        = map(string)
   default     = null
 }
+
+variable "assume_role" {
+  type    = string
+  default = "arn:aws:iam::414892725800:role/blu-jenkins-role" 
+}
+
+variable "private_record" {
+  type        = bool
+  description = "Set this variable to `true` if create record in Route53"
+  default     = true
+}
+
+variable "private_record_read_instance" {
+  type        = bool
+  description = "Set this variable to `true` if create record in Route53 for read instance"
+  default     = false
+}
+
+variable "private_record_domain" {
+  description = "Domain for record"
+  default     = "blu.com.br"
+}
+
+variable "environment" {
+  description = "Environment for private record"
+}

--- a/versions.tf
+++ b/versions.tf
@@ -7,3 +7,11 @@ terraform {
   }
 }
 
+provider "aws" {
+  alias   = "blu_shared"
+  region = "us-east-1"
+  assume_role {
+    role_arn     = var.assume_role
+  }
+}
+


### PR DESCRIPTION
Add module for Route53

- Criado modulo para adicionar record no route53 apontando para o endpoint do rds.
Se "private_record = true" o record sera criado para o endpoint de escrita e de leitura no seguinte formato.

Endpoint Gravação:  rds-environment-nome-do-serviço.domain
Endpoint Leitura: rds-ro-environment--nome-do-serviço.domain