### PR TITLE
Adding Serverless v2 functionality

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.4.0
+  rev: v4.5.0
   hooks:
   - id: check-added-large-files
     args: ['--maxkb=500']
@@ -18,7 +18,7 @@ repos:
     args: ['--allow-missing-credentials']
   - id: trailing-whitespace
 - repo: https://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.81.0
+  rev: v1.85.0
   hooks:
   - id: terraform_fmt
   - id: terraform_docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,16 @@ All notable changes to this project will be documented in this file.
 <a name="unreleased"></a>
 ## [Unreleased]
 
-- fix: assignment compatiblity issues
+- Increase minimum provider version
+- Multiple changes - rds cluster role association, cert, adding serverlessv2 scaling, secrets manager management
+- chore: update hook
+- Adapt examples to use serverless v2
+
+
+<a name="3.3.1"></a>
+## [3.3.1] - 2023-07-28
+
+- Fixing conditions ([#18](https://github.com/umotif-public/terraform-aws-rds-aurora/issues/18))
 
 
 <a name="3.3.0"></a>
@@ -115,7 +124,8 @@ All notable changes to this project will be documented in this file.
 - Initial commit
 
 
-[Unreleased]: https://github.com/umotif-public/terraform-aws-rds-aurora/compare/3.3.0...HEAD
+[Unreleased]: https://github.com/umotif-public/terraform-aws-rds-aurora/compare/3.3.1...HEAD
+[3.3.1]: https://github.com/umotif-public/terraform-aws-rds-aurora/compare/3.3.0...3.3.1
 [3.3.0]: https://github.com/umotif-public/terraform-aws-rds-aurora/compare/3.2.1...3.3.0
 [3.2.1]: https://github.com/umotif-public/terraform-aws-rds-aurora/compare/3.2.0...3.2.1
 [3.2.0]: https://github.com/umotif-public/terraform-aws-rds-aurora/compare/3.1.0...3.2.0

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ No modules.
 | [aws_rds_cluster.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster) | resource |
 | [aws_rds_cluster_instance.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster_instance) | resource |
 | [aws_rds_cluster_parameter_group.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster_parameter_group) | resource |
+| [aws_rds_cluster_role_association.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster_role_association) | resource |
 | [aws_security_group.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group_rule.main_cidr_ingress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.main_default_ingress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
@@ -130,14 +131,16 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_allocated_storage"></a> [allocated\_storage](#input\_allocated\_storage) | The amount of storage in gibibytes (GiB) to allocate to each DB instance in the Multi-AZ DB cluster | `number` | `null` | no |
 | <a name="input_allow_major_version_upgrade"></a> [allow\_major\_version\_upgrade](#input\_allow\_major\_version\_upgrade) | Enable to allow major engine version upgrades when changing engine versions. Defaults to false | `bool` | `null` | no |
 | <a name="input_allowed_cidr_blocks"></a> [allowed\_cidr\_blocks](#input\_allowed\_cidr\_blocks) | A list of CIDR blocks which are allowed to access the database | `list(string)` | `[]` | no |
 | <a name="input_allowed_security_groups"></a> [allowed\_security\_groups](#input\_allowed\_security\_groups) | A list of Security Group ID's to allow access to. | `list(string)` | `[]` | no |
 | <a name="input_apply_immediately"></a> [apply\_immediately](#input\_apply\_immediately) | Determines whether or not any DB modifications are applied immediately, or during the maintenance window | `bool` | `false` | no |
 | <a name="input_auto_minor_version_upgrade"></a> [auto\_minor\_version\_upgrade](#input\_auto\_minor\_version\_upgrade) | Determines whether minor engine upgrades will be performed automatically in the maintenance window | `bool` | `true` | no |
+| <a name="input_availability_zones"></a> [availability\_zones](#input\_availability\_zones) | List of EC2 Availability Zones for the DB cluster storage where DB cluster instances can be created. RDS automatically assigns 3 AZs if less than 3 AZs are configured, which will show as a difference requiring resource recreation next Terraform apply. | `list(string)` | `null` | no |
 | <a name="input_backtrack_window"></a> [backtrack\_window](#input\_backtrack\_window) | The target backtrack window, in seconds. Only available for aurora engine currently. To disable backtracking, set this value to 0. Defaults to 0. Must be between 0 and 259200 (72 hours) | `number` | `0` | no |
 | <a name="input_backup_retention_period"></a> [backup\_retention\_period](#input\_backup\_retention\_period) | How long to keep backups for (in days) | `number` | `7` | no |
-| <a name="input_ca_cert_identifier"></a> [ca\_cert\_identifier](#input\_ca\_cert\_identifier) | The identifier of the CA certificate for the DB instance. | `string` | `"rds-ca-2019"` | no |
+| <a name="input_ca_cert_identifier"></a> [ca\_cert\_identifier](#input\_ca\_cert\_identifier) | The identifier of the CA certificate for the DB instance. | `string` | `"rds-ca-rsa4096-g1"` | no |
 | <a name="input_cluster_instance_tags"></a> [cluster\_instance\_tags](#input\_cluster\_instance\_tags) | Additional tags for the cluster instance | `map(string)` | `{}` | no |
 | <a name="input_cluster_parameters"></a> [cluster\_parameters](#input\_cluster\_parameters) | A list of cluster parameter objects | <pre>list(object({<br>    name         = string<br>    value        = string<br>    apply_method = string<br>  }))</pre> | `[]` | no |
 | <a name="input_cluster_tags"></a> [cluster\_tags](#input\_cluster\_tags) | Additional tags for the cluster | `map(string)` | `{}` | no |
@@ -160,15 +163,20 @@ No modules.
 | <a name="input_final_snapshot_identifier_prefix"></a> [final\_snapshot\_identifier\_prefix](#input\_final\_snapshot\_identifier\_prefix) | The prefix name to use when creating a final snapshot on cluster destroy, appends a random 8 digits to name to ensure it's unique too. | `string` | `"final"` | no |
 | <a name="input_global_cluster_identifier"></a> [global\_cluster\_identifier](#input\_global\_cluster\_identifier) | The global cluster identifier specified on aws\_rds\_global\_cluster | `string` | `""` | no |
 | <a name="input_iam_database_authentication_enabled"></a> [iam\_database\_authentication\_enabled](#input\_iam\_database\_authentication\_enabled) | Specifies whether IAM Database authentication should be enabled or not. Not all versions and instances are supported. Refer to the AWS documentation to see which versions are supported. | `bool` | `true` | no |
-| <a name="input_iam_roles"></a> [iam\_roles](#input\_iam\_roles) | A List of ARNs for the IAM roles to associate to the RDS Cluster. | `list(string)` | `[]` | no |
+| <a name="input_iam_roles"></a> [iam\_roles](#input\_iam\_roles) | A Map of ARNs for the IAM roles to associate to the RDS Cluster. | `map(map(string))` | `{}` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Instance type to use | `string` | n/a | yes |
 | <a name="input_instances_parameters"></a> [instances\_parameters](#input\_instances\_parameters) | Individual settings for instances. | `list(string)` | `[]` | no |
+| <a name="input_iops"></a> [iops](#input\_iops) | Amount of Provisioned IOPS (input/output operations per second) to be initially allocated for each DB instance in the Multi-AZ DB cluster. | `number` | `null` | no |
 | <a name="input_kms_key_id"></a> [kms\_key\_id](#input\_kms\_key\_id) | The ARN for the KMS encryption key if one is set to the cluster. | `string` | `null` | no |
+| <a name="input_manage_master_user_password"></a> [manage\_master\_user\_password](#input\_manage\_master\_user\_password) | Set to true to allow RDS to manage the master user password in Secrets Manager. Cannot be set if master\_password is provided. | `bool` | `true` | no |
+| <a name="input_master_password"></a> [master\_password](#input\_master\_password) | Master DB password | `string` | `""` | no |
+| <a name="input_master_user_secret_kms_key_id"></a> [master\_user\_secret\_kms\_key\_id](#input\_master\_user\_secret\_kms\_key\_id) | Amazon Web Services KMS key identifier is the key ARN, key ID, alias ARN, or alias name for the KMS key. To use a KMS key in a different Amazon Web Services account, specify the key ARN or alias ARN. If not specified, the default KMS key for your Amazon Web Services account is used. | `string` | `null` | no |
+| <a name="input_master_username"></a> [master\_username](#input\_master\_username) | Master DB username | `string` | `"root"` | no |
 | <a name="input_monitoring_interval"></a> [monitoring\_interval](#input\_monitoring\_interval) | The interval (seconds) between points when Enhanced Monitoring metrics are collected. The default is 0. Valid Values: 0, 1, 5, 10, 15, 30, 60. | `number` | `0` | no |
 | <a name="input_monitoring_role_arn"></a> [monitoring\_role\_arn](#input\_monitoring\_role\_arn) | IAM role for RDS to send enhanced monitoring metrics to CloudWatch | `string` | `null` | no |
 | <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | Prefix Name used across all resources | `string` | n/a | yes |
+| <a name="input_network_type"></a> [network\_type](#input\_network\_type) | Network type of the cluster. Valid values: IPV4, DUAL. | `string` | `null` | no |
 | <a name="input_parameters"></a> [parameters](#input\_parameters) | A list of parameter objects | <pre>list(object({<br>    name  = string<br>    value = string<br>  }))</pre> | `[]` | no |
-| <a name="input_password"></a> [password](#input\_password) | Master DB password | `string` | `""` | no |
 | <a name="input_performance_insights_enabled"></a> [performance\_insights\_enabled](#input\_performance\_insights\_enabled) | Specifies whether Performance Insights is enabled or not. | `bool` | `false` | no |
 | <a name="input_performance_insights_kms_key_id"></a> [performance\_insights\_kms\_key\_id](#input\_performance\_insights\_kms\_key\_id) | The ARN for the KMS key to encrypt Performance Insights data. | `string` | `null` | no |
 | <a name="input_permissions_boundary"></a> [permissions\_boundary](#input\_permissions\_boundary) | The ARN of the policy that is used to set the permissions boundary for the role. | `string` | `null` | no |
@@ -183,21 +191,21 @@ No modules.
 | <a name="input_replica_scale_cpu"></a> [replica\_scale\_cpu](#input\_replica\_scale\_cpu) | CPU usage to trigger autoscaling at | `number` | `70` | no |
 | <a name="input_replica_scale_enabled"></a> [replica\_scale\_enabled](#input\_replica\_scale\_enabled) | Whether to enable autoscaling for RDS Aurora (MySQL) read replicas | `bool` | `false` | no |
 | <a name="input_replica_scale_in_cooldown"></a> [replica\_scale\_in\_cooldown](#input\_replica\_scale\_in\_cooldown) | Cooldown in seconds before allowing further scaling operations after a scale in | `number` | `300` | no |
-| <a name="input_replica_scale_max"></a> [replica\_scale\_max](#input\_replica\_scale\_max) | Maximum number of replicas to allow scaling for | `number` | `0` | no |
-| <a name="input_replica_scale_min"></a> [replica\_scale\_min](#input\_replica\_scale\_min) | Minimum number of replicas to allow scaling for | `number` | `2` | no |
+| <a name="input_replica_scale_max"></a> [replica\_scale\_max](#input\_replica\_scale\_max) | Maximum number of replicas to allow scaling for | `number` | `2` | no |
+| <a name="input_replica_scale_min"></a> [replica\_scale\_min](#input\_replica\_scale\_min) | Minimum number of replicas to allow scaling for | `number` | `0` | no |
 | <a name="input_replica_scale_out_cooldown"></a> [replica\_scale\_out\_cooldown](#input\_replica\_scale\_out\_cooldown) | Cooldown in seconds before allowing further scaling operations after a scale out | `number` | `300` | no |
 | <a name="input_replication_source_identifier"></a> [replication\_source\_identifier](#input\_replication\_source\_identifier) | ARN of a source DB cluster or DB instance if this DB cluster is to be created as a Read Replica. | `string` | `null` | no |
 | <a name="input_restore_to_point_in_time"></a> [restore\_to\_point\_in\_time](#input\_restore\_to\_point\_in\_time) | Restore to point in time configuration. See docs for arguments https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster#restore_to_point_in_time-argument-reference | `map(string)` | `{}` | no |
 | <a name="input_s3_import"></a> [s3\_import](#input\_s3\_import) | Restore from a Percona XtraBackup stored in S3 bucket. Only Aurora MySQL is supported. | `map(string)` | `null` | no |
 | <a name="input_scaling_configuration"></a> [scaling\_configuration](#input\_scaling\_configuration) | Map of nested attributes with scaling properties. Only valid when engine\_mode is set to `serverless` | `map(string)` | `{}` | no |
 | <a name="input_security_group_description"></a> [security\_group\_description](#input\_security\_group\_description) | The description of the security group. If value is set to empty string it will contain cluster name in the description. | `string` | `""` | no |
+| <a name="input_serverlessv2_scaling_configuration"></a> [serverlessv2\_scaling\_configuration](#input\_serverlessv2\_scaling\_configuration) | Nested attribute with scaling properties for ServerlessV2. Only valid when `engine_mode` is set to `provisioned` | `map(string)` | `{}` | no |
 | <a name="input_skip_final_snapshot"></a> [skip\_final\_snapshot](#input\_skip\_final\_snapshot) | Should a final snapshot be created on cluster destroy | `bool` | `false` | no |
 | <a name="input_snapshot_identifier"></a> [snapshot\_identifier](#input\_snapshot\_identifier) | DB snapshot to create this database from | `string` | `null` | no |
 | <a name="input_source_region"></a> [source\_region](#input\_source\_region) | The source region for an encrypted replica DB cluster. | `string` | `null` | no |
 | <a name="input_storage_encrypted"></a> [storage\_encrypted](#input\_storage\_encrypted) | Specifies whether the underlying storage layer should be encrypted | `bool` | `true` | no |
 | <a name="input_subnets"></a> [subnets](#input\_subnets) | List of subnet IDs to use | `list(string)` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources. | `map(string)` | `{}` | no |
-| <a name="input_username"></a> [username](#input\_username) | Master DB username | `string` | `"root"` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC ID | `string` | n/a | yes |
 | <a name="input_vpc_security_group_ids"></a> [vpc\_security\_group\_ids](#input\_vpc\_security\_group\_ids) | List of VPC security groups to associate to the cluster in addition to the SG that can be created in this module. | `list(string)` | `[]` | no |
 

--- a/README.md
+++ b/README.md
@@ -89,14 +89,14 @@ In order to activate global cluster, set `enable_global_cluster = true` when usi
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.11 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.15 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.61.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.1.1 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.15 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.61.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.1.1 |
 
 ## Modules

--- a/examples/aurora-mysql/kms.tf
+++ b/examples/aurora-mysql/kms.tf
@@ -1,3 +1,6 @@
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
 data "aws_iam_policy_document" "rds" {
   statement {
     sid = "Enable IAM User Permissions"

--- a/examples/serverless/.terraform.lock.hcl
+++ b/examples/serverless/.terraform.lock.hcl
@@ -1,0 +1,45 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.61.0"
+  constraints = ">= 4.61.0, 4.61.0"
+  hashes = [
+    "h1:qyBawxoNN6EpiiX5h5ZG5P2dHsBeA5Z67xESl2c1HRk=",
+    "zh:051e2588410b7448a5c4c30d668948dd6fdfa8037700bfc00fb228986ccbf3a5",
+    "zh:082fbcf9706b48d0880ba552a11c29527e228dadd6d83668d0789abda24e5922",
+    "zh:0e0e72f214fb24f4f9c601cab088a2d8e00ec3327c451bc753911951d773214a",
+    "zh:3af6d38ca733ca66cce15c6a5735ded7c18348ad26040ebd9a59778b2cd9cf6c",
+    "zh:404898bc2258bbb9527fa06c72cb927ca011fd9bc3f4b90931c0912652c3f9e9",
+    "zh:4f617653b0f17a7708bc896f029c4ab0b677a1a1c987bd77166acad1d82db469",
+    "zh:5dbe393355ac137aa3fd329e3d24871f27012d3ba93d714485b55820df240349",
+    "zh:6067c2127eb5c879227aca671f101de6dcba909d0d8d15d5711480351962a248",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a939f94461f91aa3b7ec7096271e2714309bd917fe9a03e02f68afb556d65e0f",
+    "zh:b21227b9082e5fafe8b7c415dc6a99c0d82da05492457377a5fe7d4acaed80e2",
+    "zh:b8d9f09ed5fc8c654b768b7bee1237eaf1e2287c898249e740695055fb0fe072",
+    "zh:d360e1e185b148ff6b1d0ed4f7d574e08f2391697ab43df62085b04a1a5b1284",
+    "zh:da962da17ddda744911cb1e92b983fa3874d73a28f3ee72faa9ddb6680a63774",
+    "zh:e2f1c4f5ebeb4fd7ef690178168a4c529025b54a91bb7a087dcea48e0b82737a",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.1.1"
+  constraints = ">= 3.1.1, 3.1.1"
+  hashes = [
+    "h1:o6mw4IX7BNxtZrTP0cVYxc/5xsTB0LcpQhEHkOyFoXI=",
+    "zh:04dbe3a562a5da087aca7729332dc4bdba763e71a7a9fcf2b71d38454af8975d",
+    "zh:23ad79fbd96be6271560cb78855b51129845a1a52edff19f6725f99851e36367",
+    "zh:34678e44716d76bfad398506757680b3285bf8b2704e0637fcec9c3f3b659f85",
+    "zh:46c64dfa7c7c48576240cda9a022e84e4a4bd049d22bcb8e5a72b9ceebf24838",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b6a9d785c5d1fbd18d3f9f7130ce8a9f3b95ec3e14ba0f1a5ae557f50b2b58a",
+    "zh:be00333ae3bbb520d205d8dcf7ddb84fad60cbe0104b6f45bb1fa8d37ad1fbfb",
+    "zh:cce05ea51cb86ca5cc4bd11a6f9d7c0463cdf74bc45bccbdcbc2b3a6c6465248",
+    "zh:d5d065af722ad73874f952c0a0d75a35e7c58bceba153b2411e869ad41ff0aa8",
+    "zh:e8e7abadccca7f484f4e8bb4d2639ba3e89efa94f1d456eb5f173f7053127d63",
+    "zh:f6b9d9947026ea4e7bb9a2e7c4f15a57dbf26d7b3799df24405a3e7bc0d9ea00",
+    "zh:ff0cfd9c52c724aef6ffda20285b7fb77b6b044f39308a95dc4f993993802bb4",
+  ]
+}

--- a/examples/serverless/versions.tf
+++ b/examples/serverless/versions.tf
@@ -3,17 +3,17 @@ provider "aws" {
 }
 
 terraform {
-  required_version = ">= 1.0.11"
+  required_version = "1.0.11"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.55"
+      version = "4.61"
     }
 
     random = {
       source  = "hashicorp/random"
-      version = ">= 3.1.1"
+      version = "3.1.1"
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -61,13 +61,13 @@ variable "database_name" {
   default     = ""
 }
 
-variable "username" {
+variable "master_username" {
   description = "Master DB username"
   type        = string
   default     = "root"
 }
 
-variable "password" {
+variable "master_password" {
   description = "Master DB password"
   type        = string
   default     = ""
@@ -202,13 +202,13 @@ variable "replica_scale_enabled" {
 variable "replica_scale_max" {
   description = "Maximum number of replicas to allow scaling for"
   type        = number
-  default     = 0
+  default     = 2
 }
 
 variable "replica_scale_min" {
   description = "Minimum number of replicas to allow scaling for"
   type        = number
-  default     = 2
+  default     = 0
 }
 
 variable "replica_scale_cpu" {
@@ -320,9 +320,9 @@ variable "copy_tags_to_snapshot" {
 }
 
 variable "iam_roles" {
-  description = "A List of ARNs for the IAM roles to associate to the RDS Cluster."
-  type        = list(string)
-  default     = []
+  description = "A Map of ARNs for the IAM roles to associate to the RDS Cluster."
+  type        = map(map(string))
+  default     = {}
 }
 
 variable "security_group_description" {
@@ -334,7 +334,7 @@ variable "security_group_description" {
 variable "ca_cert_identifier" {
   description = "The identifier of the CA certificate for the DB instance."
   type        = string
-  default     = "rds-ca-2019"
+  default     = "rds-ca-rsa4096-g1"
 }
 
 variable "instances_parameters" {
@@ -419,5 +419,47 @@ variable "restore_to_point_in_time" {
 variable "s3_import" {
   description = "Restore from a Percona XtraBackup stored in S3 bucket. Only Aurora MySQL is supported."
   type        = map(string)
+  default     = null
+}
+
+variable "serverlessv2_scaling_configuration" {
+  description = "Nested attribute with scaling properties for ServerlessV2. Only valid when `engine_mode` is set to `provisioned`"
+  type        = map(string)
+  default     = {}
+}
+
+variable "allocated_storage" {
+  description = "The amount of storage in gibibytes (GiB) to allocate to each DB instance in the Multi-AZ DB cluster"
+  type        = number
+  default     = null
+}
+
+variable "availability_zones" {
+  description = "List of EC2 Availability Zones for the DB cluster storage where DB cluster instances can be created. RDS automatically assigns 3 AZs if less than 3 AZs are configured, which will show as a difference requiring resource recreation next Terraform apply."
+  type        = list(string)
+  default     = null
+}
+
+variable "iops" {
+  description = "Amount of Provisioned IOPS (input/output operations per second) to be initially allocated for each DB instance in the Multi-AZ DB cluster."
+  type        = number
+  default     = null
+}
+
+variable "manage_master_user_password" {
+  description = "Set to true to allow RDS to manage the master user password in Secrets Manager. Cannot be set if master_password is provided."
+  type        = bool
+  default     = true
+}
+
+variable "master_user_secret_kms_key_id" {
+  description = "Amazon Web Services KMS key identifier is the key ARN, key ID, alias ARN, or alias name for the KMS key. To use a KMS key in a different Amazon Web Services account, specify the key ARN or alias ARN. If not specified, the default KMS key for your Amazon Web Services account is used."
+  type        = string
+  default     = null
+}
+
+variable "network_type" {
+  description = "Network type of the cluster. Valid values: IPV4, DUAL."
+  type        = string
   default     = null
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.15"
+      version = ">= 4.61.0"
     }
 
     random = {


### PR DESCRIPTION
# Description

Multiple changes:

1. Serverless v2 functionality
2. RDS Cluster Role Association terraform resource
3. Updating CA Cert
4. Add the ability to use Secrets Manager to manage RDS password
5. Raising the minimum provider version to 4.61
6. New attributes
a. iops
b. allocated_storage
c.  availability_zones
d.  network_type  
7. chore: updating hooks & changelog